### PR TITLE
Bump to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 - Easy integration in Rails
 - Allow to pick your own infinity format
 
+# 1.1.0
+- Add official support for ruby 3.2.2
+
 ## 1.0.1
 - Fix options validator bug
 - Modify gem description

--- a/lib/availabiliter/version.rb
+++ b/lib/availabiliter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Availabiliter
-  VERSION = "1.0.1"
+  VERSION = "1.1.O"
 end

--- a/rakelib/test_ruby_versions.rake
+++ b/rakelib/test_ruby_versions.rake
@@ -3,7 +3,7 @@ require_relative "../lib/availabiliter"
 
 desc "Run the tests against all ruby versions"
 task :test_ruby_versions do
-  authorized_versions = ["3.1.2", "3.0.4", "2.7.6", "2.7.2"]
+  authorized_versions = ["3.2.2", "3.1.4", "3.0.6", "2.7.8", "2.7.2"]
 
   authorized_versions.each do |version|
     print "---------RUNNING TEST FOR RUBY #{version}---------"


### PR DESCRIPTION
### Goal

Bump a new version of availabiliter to make sure it can run with the most recent ruby versions: 
- 3.2.2
- 3.1.4
- 3.0.6
- 2.7.8